### PR TITLE
Vagrant environment, for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pixiecore
 example/example
+.vagrant
+

--- a/README.md
+++ b/README.md
@@ -238,3 +238,15 @@ This is what the whole boot process looks like on the wire.
 - PXE ROM downloads PXELINUX from Pixiecore's TFTP server, and hands off to PXELINUX.
 - PXELINUX fetches its configuration from Pixiecore's HTTP server.
 - PXELINUX fetches a kernel and ramdisk from Pixiecore's HTTP server, and boots Linux.
+
+## Development
+You can use [Vagrant](https://www.vagrantup.com/) to quickly setup a test environment:
+
+    (HOST)$ vagrant up --provider=libvirt pxeserver
+    (HOST)$ vagrant ssh pxeserver
+    (PXESERVER)$ wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe.vmlinuz
+    (PXESERVER)$ wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_pxe_image.cpio.gz
+    (PXESERVER)$ pixiecore -debug -kernel coreos_production_pxe.vmlinuz -initrd coreos_production_pxe_image.cpio.gz --cmdline coreos.autologin
+    ### In another terminal
+    (HOST)$ vagrant up --provider=libvirt pxeclient1
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
+unless Vagrant.has_plugin?("vagrant-libvirt")
+  raise Vagrant::Errors::VagrantError.new, "Please install the vagrant-libvirt plugin running 'vagrant plugin install vagrant-libvirt'"
+end
+
+Vagrant.configure("2") do |config|
+  config.vm.define :pxeserver do |pxeserver|
+    pxeserver.vm.box = "naelyn/ubuntu-trusty64-libvirt"
+    pxeserver.vm.network :private_network, :ip => '10.10.10.2'
+    pxeserver.vm.provision :shell, path: 'vagrant_provision.sh'
+  end
+
+  config.vm.define :pxeclient1 do |pxeclient1|
+    pxeclient1.vm.provider :libvirt do |pxeclient1_vm|
+      pxeclient1_vm.storage :file, :size => '20G', :type => 'qcow2'
+      pxeclient1_vm.boot 'network'
+      pxeclient1_vm.boot 'hd'
+    end
+  end
+end
+

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+apt-get update -qy
+apt-get upgrade -qy
+apt-get install -qy git
+
+if [ ! -f /usr/local/go/bin/go ]; then
+    cd /tmp
+    wget -qcO go.tar.gz https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go.tar.gz
+    rm go.tar.gz
+fi
+export PATH=$PATH:/usr/local/go/bin
+
+mkdir -p /go/src/github.com/danderson
+export GOPATH=/go
+ln -s /vagrant /go/src/github.com/danderson/pixiecore
+
+cd /go/src/github.com/danderson/pixiecore
+go get golang.org/x/crypto/nacl/secretbox
+go get golang.org/x/net/ipv4
+go build -o /usr/local/bin/pixiecore .
+
+cat > /etc/profile.d/go.sh <<EOF
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=/go
+EOF
+


### PR DESCRIPTION
libvirt was required, because the default engine doesn't support empty machines, at least [not so easily](https://github.com/mitchellh/vagrant/issues/4487).
