### PR TITLE
allow binding to specific address

### DIFF
--- a/dhcp.go
+++ b/dhcp.go
@@ -20,8 +20,8 @@ type DHCPPacket struct {
 	ServerIP net.IP
 }
 
-func ServeProxyDHCP(port int, booter Booter) error {
-	conn, err := net.ListenPacket("udp4", fmt.Sprintf(":%d", port))
+func ServeProxyDHCP(addr string, booter Booter) error {
+	conn, err := net.ListenPacket("udp4", addr)
 	if err != nil {
 		return err
 	}
@@ -31,7 +31,7 @@ func ServeProxyDHCP(port int, booter Booter) error {
 		return err
 	}
 
-	Log("ProxyDHCP", "Listening on port %d", port)
+	Log("ProxyDHCP", "Listening on %s", addr)
 	buf := make([]byte, 1024)
 	for {
 		n, msg, addr, err := l.ReadFrom(buf)

--- a/http.go
+++ b/http.go
@@ -115,7 +115,7 @@ func (s *httpServer) File(w http.ResponseWriter, r *http.Request) {
 	Log("HTTP", "Sent %s to %s (%d bytes)", pretty, r.RemoteAddr, written)
 }
 
-func ServeHTTP(port int, booter Booter, ldlinux []byte) error {
+func ServeHTTP(addr string, port int, booter Booter, ldlinux []byte) error {
 	s := &httpServer{
 		booter:  booter,
 		ldlinux: ldlinux,
@@ -129,6 +129,7 @@ func ServeHTTP(port int, booter Booter, ldlinux []byte) error {
 	http.HandleFunc("/pxelinux.cfg/", s.PxelinuxConfig)
 	http.HandleFunc("/f/", s.File)
 
-	Log("HTTP", "Listening on port %d", port)
-	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	httpAddr := fmt.Sprintf("%s:%d", addr, port)
+	Log("HTTP", "Listening on %s", httpAddr)
+	return http.ListenAndServe(httpAddr, nil)
 }

--- a/pxe.go
+++ b/pxe.go
@@ -19,8 +19,8 @@ type PXEPacket struct {
 	HTTPServer string
 }
 
-func ServePXE(pxePort, httpPort int) error {
-	conn, err := net.ListenPacket("udp4", fmt.Sprintf(":%d", pxePort))
+func ServePXE(pxeAddr string, httpPort int) error {
+	conn, err := net.ListenPacket("udp4", pxeAddr)
 	if err != nil {
 		return err
 	}
@@ -30,7 +30,7 @@ func ServePXE(pxePort, httpPort int) error {
 		return err
 	}
 
-	Log("PXE", "Listening on port %d", pxePort)
+	Log("PXE", "Listening on %s", pxeAddr)
 	buf := make([]byte, 1024)
 	for {
 		n, msg, addr, err := l.ReadFrom(buf)


### PR DESCRIPTION
add support for binding to a single address instead of all interfaces with `--listen-addr=...`
fixes #12
