### PR TITLE
Added option to load from file, customized labels

### DIFF
--- a/http.go
+++ b/http.go
@@ -21,7 +21,7 @@ LOCALBOOT 0
 
 // A silly limerick displayed while pxelinux loads big OS
 // images. Possibly the most important piece of this program.
-const limerick = `
+var message string = `
 	        There once was a protocol called PXE,
 	        Whose specification was overly tricksy.
 	        A committee refined it,
@@ -75,12 +75,14 @@ func (s *httpServer) PxelinuxConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if (len(spec.Message) > 0) { message = spec.Message }
+
 	var cfg bytes.Buffer
 	fmt.Fprintf(&cfg, `SAY %s
 DEFAULT linux
 LABEL linux
 KERNEL %s
-`, strings.Replace(limerick, "\n", "\nSAY ", -1), spec.Kernel)
+`, strings.Replace(message, "\n", "\nSAY ", -1), spec.Kernel)
 	args := spec.Cmdline
 	if len(spec.Initrd) > 0 {
 		args = fmt.Sprintf("initrd=%s %s", strings.Join(spec.Initrd, ","), args)
@@ -136,6 +138,7 @@ func serveHTTP(addr string, port int, booter Booter, ldlinux []byte) error {
 	http.HandleFunc("/ldlinux.c32", s.Ldlinux)
 	http.HandleFunc("/pxelinux.cfg/", s.PxelinuxConfig)
 	http.HandleFunc("/f/", s.File)
+	http.HandleFunc("/", s.File)
 
 	httpAddr := fmt.Sprintf("%s:%d", addr, port)
 	Log("HTTP", "Listening on %s", httpAddr)


### PR DESCRIPTION
We're looking to use Pixiecore in a setup that serves public access computers. The idea is that a centralized server will determine the boot parameters, while the images themselves will be loaded from local NFS mounts.

For this purpose, two features were added:
- optional flag to load from file system instead of HTTP
- optional message to be printed during boot. Useful for conveying error messages
  or letting the admin know which image is being loaded in a test environment.

The code likely isn't the best, as not all the use cases for this program are clear to me. Improvement suggestions would be very welcome.
