### PR TITLE
Add file urls customized lables take2

### DIFF
--- a/README.api.md
+++ b/README.api.md
@@ -39,6 +39,7 @@ following specification, with **_italicized_** entries being optional:
     that it proxies the request (see below for why you'd want that).
     - **url** (string): any URL. Pixiecore will rewrite the URL such
       that it proxies the request.
+- **_message_** (string): customized message to be printed to client terminal
 
 Malformed 200 responses will have the same result as a non-200
 response - Pixiecore will ignore the requesting machine.
@@ -78,6 +79,9 @@ definitely not okay for retrieval over the internet. Proxying through
 Pixiecore means that your API server can provide HTTPS URLs, and
 everything but the very last mile between Pixiecore and the machine
 will be secure.
+
+Alternatively, the images **could** be loaded from file. Anyone wishing
+to do so, must set the file paths as absolute file URL's.
 
 The exact URLs visible to the booting machine are an implementation
 detail of Pixiecore and are subject to breaking change at any
@@ -139,6 +143,16 @@ Boot from HTTPS, with extra commandline flags.
     "selinux": "1",
     "coreos.autologin": true
   }
+}
+```
+
+Boot from file URL, and display a custom label
+
+```json
+{
+  "kernel": "file:/kernel",
+  "initrd": ["file:/initrd.0", "file:/initrd.1"],
+  "message": "We bring good tidings"
 }
 ```
 

--- a/http.go
+++ b/http.go
@@ -21,7 +21,7 @@ LOCALBOOT 0
 
 // A silly limerick displayed while pxelinux loads big OS
 // images. Possibly the most important piece of this program.
-var message string = `
+const limerick = `
 	        There once was a protocol called PXE,
 	        Whose specification was overly tricksy.
 	        A committee refined it,
@@ -75,9 +75,10 @@ func (s *httpServer) PxelinuxConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if (len(spec.Message) > 0) { message = spec.Message }
+    var message string
+	if (len(spec.Message) > 0) {message = spec.Message} else {message = limerick}
 
-	var cfg bytes.Buffer
+    var cfg bytes.Buffer
 	fmt.Fprintf(&cfg, `SAY %s
 DEFAULT linux
 LABEL linux

--- a/http.go
+++ b/http.go
@@ -21,7 +21,7 @@ LOCALBOOT 0
 
 // A silly limerick displayed while pxelinux loads big OS
 // images. Possibly the most important piece of this program.
-const limerick = `
+var message string = `
 	        There once was a protocol called PXE,
 	        Whose specification was overly tricksy.
 	        A committee refined it,
@@ -75,12 +75,14 @@ func (s *httpServer) PxelinuxConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if (len(spec.Message) > 0) { message = spec.Message }
+
 	var cfg bytes.Buffer
 	fmt.Fprintf(&cfg, `SAY %s
 DEFAULT linux
 LABEL linux
 KERNEL %s
-`, strings.Replace(limerick, "\n", "\nSAY ", -1), spec.Kernel)
+`, strings.Replace(message, "\n", "\nSAY ", -1), spec.Kernel)
 	args := spec.Cmdline
 	if len(spec.Initrd) > 0 {
 		args = fmt.Sprintf("initrd=%s %s", strings.Join(spec.Initrd, ","), args)
@@ -136,6 +138,7 @@ func serveHTTP(addr string, port int, booter Booter, ldlinux []byte) error {
 	http.HandleFunc("/ldlinux.c32", s.Ldlinux)
 	http.HandleFunc("/pxelinux.cfg/", s.PxelinuxConfig)
 	http.HandleFunc("/f/", s.File)
+	http.HandleFunc("/", s.File)
 
 	httpAddr := fmt.Sprintf("%s:%d", addr, port)
 	Log("HTTP", "Listening on %s", httpAddr)


### PR DESCRIPTION
Thanks for your earlier reply.

I've tried to clean it up as per your recommendations, but my knowledge of Go is very cursory. Don't feel very confident about lines api.go:177-178, but couldn't find the other way. The reason I'm still nulling urlPrefix, is to avoid potentially confusing "Loading http:..." prints to the client terminal (the strings are still signed, though)

As to your earlier comment: While we could serve the images over the central server, boot times are already a bit of an issue. Local mounts are needed anyway for the nfsroot, so some degree of coupling is pretty much unavoidable. Squirming out of it won't necessarily mean less overall work, either. The supplied code isn't terribly elegant, but the functionality comes in very handy...
